### PR TITLE
Refresh page after Mercure disconnection

### DIFF
--- a/assets/app.ts
+++ b/assets/app.ts
@@ -17,6 +17,12 @@ async function startApp(): Promise<void>
     });
 
     setInterval(() => {
+        if (window.refreshPage)
+        {
+            location.reload();
+            return;
+        }
+
         const length = store.slides.length;
 
         if (length < 1)

--- a/assets/helpers/api.ts
+++ b/assets/helpers/api.ts
@@ -37,6 +37,12 @@ function subscribeToEvents(handler: (event: MessageEvent) => void): void
         }
     );
 
+    eventSource.onopen = () => {
+        eventSource.onerror = () => {
+            window.refreshPage = true;
+        }
+    }
+
     eventSource.onmessage = handler;
 }
 

--- a/assets/types/lib.dom.d.ts
+++ b/assets/types/lib.dom.d.ts
@@ -3,5 +3,6 @@ export declare global
     interface Window
     {
         mercureHub: string;
+        refreshPage: boolean;
     }
 }


### PR DESCRIPTION
The JWT authentication token has an expiry time of one hour. After this, the Mercure event source would disconnect due to a 401 HTTP response. To overcome this, a whole page refresh is triggered in the event of a connection error with the event source.

The page refresh will only be triggered following a previous successful connection. This is to prevent a constant refresh if the Mercure hub is not reachable on initial page load.