### PR TITLE
Workaround for scoped styles type error

### DIFF
--- a/assets/components/authorisationRequest.vue
+++ b/assets/components/authorisationRequest.vue
@@ -19,7 +19,7 @@
     });
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
     p.code {
         font-size: 2em;
 


### PR DESCRIPTION
Using scoped styles in Vue SFCs currently results in an implicit any type error. To work around this bug, styles are now non-scope.